### PR TITLE
Add `createDocument` and `installIndexTemplate`

### DIFF
--- a/grails-app/services/com/morpheus/grails/elasticsearch/ElasticAdminService.groovy
+++ b/grails-app/services/com/morpheus/grails/elasticsearch/ElasticAdminService.groovy
@@ -385,6 +385,13 @@ class ElasticAdminService {
 		return aliasResults
 	}
 
+	// create an index template (this endpoint is used for datastreams)
+	def installIndexTemplate(String name, Map config) {
+		def templateResults = elasticService.executePut('_index_template', name, config)
+		log.debug("install template: {}", templateResults)
+		return templateResults
+	}
+
 	//templates
 	def installTemplate(String name, Map config) {
 		def templateResults = elasticService.executePut('_template', name, config)


### PR DESCRIPTION
These functions are needed to use the datastream API in elasticsearch. See this guide for more information:
https://opensearch.org/docs/latest/im-plugin/data-streams/

createDocument is needed because elasticsearch datastreams only support POST operations, not PUT (which is what is currently used by the plugin for all creation and updating of records).