### PR TITLE
Add missing return statements for method chaining

### DIFF
--- a/src/main/groovy/com/morpheus/grails/elasticsearch/ElasticAggregation.groovy
+++ b/src/main/groovy/com/morpheus/grails/elasticsearch/ElasticAggregation.groovy
@@ -68,6 +68,7 @@ class ElasticAggregation {
 		def subAggregation(Object aggregation) {
 			body[name].aggs = body[name].aggs ?: [:]
 			body[name].aggs << aggregation.body
+			return this
 		}
 
 		def setBaseKeyValue(String key, Object value) {
@@ -299,6 +300,18 @@ class ElasticAggregation {
 			return this
 		}
 
+		def setSize(Integer size) {
+			aggTarget.size = size
+			return this
+		}
+
+		def addSort(String field, String order) {
+			aggTarget.sort = aggTarget.sort ?: []
+			def newSort = [:]
+			newSort[field] = [order:order?.toLowerCase()]
+			aggTarget.sort << newSort
+			return this
+		}
 	}
 
 	//internal stuff

--- a/src/main/groovy/com/morpheus/grails/elasticsearch/ElasticQueryBuilder.groovy
+++ b/src/main/groovy/com/morpheus/grails/elasticsearch/ElasticQueryBuilder.groovy
@@ -241,10 +241,12 @@ class ElasticQueryBuilder {
 
 		def setSize(Integer size) {
 			body.size = size
+			return this
 		}
 
 		def setFrom(Integer from) {
 			body.from = from
+			return this
 		}
 
 		def addSort(String field, String order) {
@@ -252,11 +254,13 @@ class ElasticQueryBuilder {
 			def newSort = [:]
 			newSort[field] = [order:order?.toLowerCase()]
 			body.sort << newSort
+			return this
 		}
 
 		def setQuery(query) {
 			body.query = query.body
 			queryTarget = body.query
+			return this
 		}
 
 		def getMultiQuery() {
@@ -539,6 +543,7 @@ class ElasticQueryBuilder {
 
 		def boost(Double value) {
 			queryTarget.boost = value
+			return this
 		}
 
 	}


### PR DESCRIPTION
Also add addSort and setSize to metricAggregation to help with method chaining.

This plugin has an established pattern where all setter methods return the updated object so that more methods may be called on them in sequence. Some of these methods are missing this return statement and because of that it is difficult to layout queries nicely. This adds those return statements where they would be expected.