### PR TITLE
Fix an issue where `installDomainMappings` is run repeatedly

### DIFF
--- a/grails-app/services/com/morpheus/grails/elasticsearch/ElasticAdminService.groovy
+++ b/grails-app/services/com/morpheus/grails/elasticsearch/ElasticAdminService.groovy
@@ -45,6 +45,8 @@ class ElasticAdminService {
 	static Map<String, String> indexAliases = [:]
 	static Map<String, String> indexVersions = [:]
 
+	static boolean domainMappingsInstalled = false
+
 	//queueing structures
 	def indexRequests = [:]
 	def deleteRequests = [:]
@@ -86,7 +88,8 @@ class ElasticAdminService {
 	}
 
 	Map getIndexMapping() {
-		if(indexMap?.size() == 0) {
+		// if installDomainMappings was already run, don't run it again.
+		if(indexMap?.size() == 0 && !domainMappingsInstalled) {
 			synchronized(startupMutex) {
 				//reload it
 				installDomainMappings()
@@ -181,6 +184,7 @@ class ElasticAdminService {
 				}
 			}
 		}
+		domainMappingsInstalled = true
 		log.info("elastic - finished installing domain mappings")
 	}
 


### PR DESCRIPTION
Our service doesn't have any searchable domain classes, so indexMap in ElasticAdminService will always be empty. The current check in ElasticAdminService to see if domain mappings need to be installed is to check is indexMap is empty, meaning on our case it runs on every database insertion. This adds a check to make sure that installDomainMappings is only run once.