### PR TITLE
Remove CVE-2025-48734

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation "org.grails:grails-plugin-services"
     implementation "org.grails:grails-plugin-url-mappings"
     implementation "org.grails:grails-plugin-interceptors"
-    api group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
+    api group: 'commons-beanutils', name: 'commons-beanutils', version: '1.11.0'
     api "org.grails.plugins:hibernate5"
     implementation "org.grails.plugins:cache"
     api 'org.elasticsearch.client:elasticsearch-rest-client:7.9.0'


### PR DESCRIPTION
I updated the of `commons-beanutils:commons-beanutils` to
version 1.11.0 as per https://nvd.nist.gov/vuln/detail/CVE-2025-48734